### PR TITLE
Add environment configuration tooling and updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,83 +1,10 @@
-# Top-TieR Global HUB AI - Environment Configuration
-# Copy this file to .env and modify the values as needed
-
-# API Server Configuration
-API_HOST=0.0.0.0
-API_PORT=8000
-DEBUG=false
-
-# Application Settings
-APP_NAME=Top-TieR-Global-HUB-AI
-APP_VERSION=2.0.0
-ENVIRONMENT=production
-
-# Database Configuration (if using database)
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/app_db
-REDIS_URL=redis://localhost:6379/0
-
-# Neo4j Graph Database Configuration
-NEO4J_URL=bolt://localhost:7687
-NEO4J_USER=neo4j
-NEO4J_PASSWORD=password
-
-# MinIO Object Storage Configuration
-MINIO_ENDPOINT=http://localhost:9000
-MINIO_ACCESS_KEY=minioadmin
-MINIO_SECRET_KEY=minioadmin
-MINIO_BUCKET_NAME=osint-data
-MINIO_SECURE=false
-
-# OpenSearch Configuration
-OPENSEARCH_HOST=localhost
-OPENSEARCH_PORT=9200
-OPENSEARCH_SCHEME=http
-OPENSEARCH_INDEX_PREFIX=osint
-
-# Security Settings
-# SECRET_KEY=your-secret-key-here
-# JWT_SECRET=your-jwt-secret-here
-
-# External API Keys (for OSINT data sources)
-# OSINT_API_KEY=your-osint-api-key
-# SOCIAL_MEDIA_API_KEY=your-social-media-api-key
-# OPENAI_API_KEY=your-openai-api-key
-
-# Logging Configuration
-LOG_LEVEL=INFO
-LOG_FORMAT=json
-
-# Rate Limiting
-RATE_LIMIT_REQUESTS=100
-RATE_LIMIT_WINDOW=60
-
-# CORS Settings
-CORS_ORIGINS=["http://localhost:3000", "http://localhost:8080"]
-CORS_METHODS=["GET", "POST", "PUT", "DELETE"]
-CORS_HEADERS=["*"]
-
-# Cache Configuration
-REDIS_URL=redis://localhost:6379/0
-CACHE_TTL=300
-CACHE_PREFIX=osint
-
-# Worker Configuration
-WORKER_PROCESSES=4
-WORKER_TIMEOUT=30
-
-# Data Processing Configuration
-MAX_FILE_SIZE=100MB
-ALLOWED_FILE_TYPES=pdf,txt,json,csv,xml
-DATA_RETENTION_DAYS=365
-
-# Search Configuration
-SEARCH_RESULTS_LIMIT=100
-SEARCH_TIMEOUT=30
-
-# Health Check Configuration
-HEALTH_CHECK_INTERVAL=30
-HEALTH_CHECK_TIMEOUT=10
-
-# Monitoring Configuration
-ENABLE_METRICS=true
-METRICS_PORT=9090
-METRICS_PATH=/metrics
+OPENAI_API_KEY=sk-...
+DB_URL=postgresql://postgres:motebai@postgres:5432/motebai
+OPENSEARCH_URL=http://opensearch:9200
+MINIO_ENDPOINT=http://minio:9000
+MINIO_ROOT_USER=motebai
+MINIO_ROOT_PASSWORD=motebai123
+REDIS_URL=redis://redis:6379
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_AUTH=neo4j/motebai
+CLICKHOUSE_URL=http://clickhouse:8123

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,17 @@
 name: CI
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   push:
     branches: [ main, master ]

--- a/.github/workflows/Immutable-Release.yml
+++ b/.github/workflows/Immutable-Release.yml
@@ -10,6 +10,16 @@ permissions:
 
 env:
   IMAGE_NAME: veritas-console
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
 
 jobs:
   build-release:

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -1,4 +1,17 @@
 name: Auto Assign Reviewer
+
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   pull_request:
     types: [opened, reopened, ready_for_review]

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,5 +1,17 @@
 name: Repository Hygiene - Close Old Issues & PRs
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,18 @@
 ---
 name: "CodeQL"
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 'on':
   push:
     branches: ["main", "master"]

--- a/.github/workflows/comment-on-pr6.yml
+++ b/.github/workflows/comment-on-pr6.yml
@@ -1,4 +1,17 @@
-name: Comment on PR #6  
+name: Comment on PR #6
+
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/context-collector.yml
+++ b/.github/workflows/context-collector.yml
@@ -1,5 +1,17 @@
 name: Context Collector
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/daily-readonly-check.yml
+++ b/.github/workflows/daily-readonly-check.yml
@@ -1,6 +1,18 @@
 ---
 name: Daily Readonly Health (Dry-run)
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 "on":
   schedule:
     - cron: "0 7 * * *"   # daily at 07:00 UTC

--- a/.github/workflows/external-api-diagnosis.yml
+++ b/.github/workflows/external-api-diagnosis.yml
@@ -1,5 +1,17 @@
 name: External API Diagnosis
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   schedule:
     - cron: "0 */6 * * *"   # كل 6 ساعات (تقدر تعدل)

--- a/.github/workflows/generate-repo-summary.yml
+++ b/.github/workflows/generate-repo-summary.yml
@@ -1,5 +1,17 @@
 name: Generate repository summary
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   workflow_dispatch: {}
   push:

--- a/.github/workflows/post-merge-validation.yml
+++ b/.github/workflows/post-merge-validation.yml
@@ -1,5 +1,17 @@
 ---
 name: Post-merge Validation (Readonly)
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 "on":
   push:
     branches: [main]

--- a/.github/workflows/post_merge_validation.yml
+++ b/.github/workflows/post_merge_validation.yml
@@ -1,5 +1,17 @@
 name: Post Merge Validation
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   push:
     branches:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,4 +1,17 @@
 name: Sync labels
+
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/veritas-health.yml
+++ b/.github/workflows/veritas-health.yml
@@ -1,5 +1,17 @@
 name: Veritas Nexus • Health (Auto)
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   push:
     branches: [ main, develop ]

--- a/README.md
+++ b/README.md
@@ -360,3 +360,10 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ---
 
 **Note**: This is an educational OSINT platform. Please use responsibly and in compliance with applicable laws and regulations.
+
+## 🔑 Environment Setup
+
+1. Copy `.env.example` → `.env`
+2. Fill in real values (keys, URLs, passwords).
+3. Add them into GitHub Secrets with the same names.
+4. Docker Compose and GitHub Actions will automatically pick them up.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,22 @@ services:
     build: .
     ports:
       - "8000:8000"
+    env_file:
+      - .env
     environment:
       - API_HOST=0.0.0.0
       - API_PORT=8000
       - ENVIRONMENT=development
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - DB_URL=${DB_URL}
+      - OPENSEARCH_URL=${OPENSEARCH_URL}
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT}
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+      - REDIS_URL=${REDIS_URL}
+      - NEO4J_URI=${NEO4J_URI}
+      - NEO4J_AUTH=${NEO4J_AUTH}
+      - CLICKHOUSE_URL=${CLICKHOUSE_URL}
     depends_on:
       - redis
       - postgres
@@ -57,10 +69,11 @@ services:
       - "7474:7474"
       - "7687:7687"
     env_file:
+      - .env
       - /opt/veritas/.env.neo4j
     environment:
       - NEO4J_dbms_security_auth__enabled=true
-      - NEO4J_AUTH=${NEO4J_USER}:${NEO4J_PASSWORD}
+      - NEO4J_AUTH=${NEO4J_AUTH}
     volumes:
       - neo4j-data:/data
     healthcheck:
@@ -77,8 +90,8 @@ services:
       - "9000:9000"
       - "9001:9001"
     environment:
-      - MINIO_ROOT_USER=minioadmin
-      - MINIO_ROOT_PASSWORD=minioadmin
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
       - MINIO_SERVER_URL=http://localhost:9000
       - MINIO_BROWSER_REDIRECT_URL=http://localhost:9001
     command: server /data --console-address ":9001"

--- a/scripts/generate_env_and_patch_workflows.py
+++ b/scripts/generate_env_and_patch_workflows.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Utility script to align environment configuration across the repository.
+
+It will:
+- Generate or refresh `.env.example` with the required environment variables.
+- Inject shared secret references into each workflow under `.github/workflows/`.
+- Ensure `docker-compose.yml` consumes those environment variables.
+- Append an "Environment Setup" section to the README when missing.
+"""
+
+from pathlib import Path
+import re
+
+ENV_VARS = {
+    "OPENAI_API_KEY": "sk-...",
+    "DB_URL": "postgresql://postgres:motebai@postgres:5432/motebai",
+    "OPENSEARCH_URL": "http://opensearch:9200",
+    "MINIO_ENDPOINT": "http://minio:9000",
+    "MINIO_ROOT_USER": "motebai",
+    "MINIO_ROOT_PASSWORD": "motebai123",
+    "REDIS_URL": "redis://redis:6379",
+    "NEO4J_URI": "bolt://neo4j:7687",
+    "NEO4J_AUTH": "neo4j/motebai",
+    "CLICKHOUSE_URL": "http://clickhouse:8123",
+}
+
+SECRET_VALUES = {key: f"${{{{ secrets.{key} }}}}" for key in ENV_VARS}
+
+README_SECTION = """
+## 🔑 Environment Setup
+
+1. Copy `.env.example` → `.env`
+2. Fill in real values (keys, URLs, passwords).
+3. Add them into GitHub Secrets with the same names.
+4. Docker Compose and GitHub Actions will automatically pick them up.
+"""
+
+
+def write_env_example() -> None:
+    env_file = Path(".env.example")
+    lines = [f"{key}={value}\n" for key, value in ENV_VARS.items()]
+    env_file.write_text("".join(lines))
+    print("✅ Generated .env.example")
+
+
+def _parse_env_block(lines, start_index):
+    block_lines = []
+    index = start_index + 1
+    while index < len(lines) and (lines[index].startswith("  ") or lines[index].strip() == ""):
+        block_lines.append(lines[index])
+        index += 1
+    return block_lines, index
+
+
+def patch_workflow(path: Path) -> bool:
+    content = path.read_text()
+    lines = content.splitlines(keepends=True)
+
+    root_env_idx = next((i for i, line in enumerate(lines) if line.startswith("env:")), None)
+    changed = False
+
+    if root_env_idx is not None:
+        block_lines, block_end = _parse_env_block(lines, root_env_idx)
+        env_entries = {}
+        for raw in block_lines:
+            stripped = raw.strip()
+            if not stripped or stripped.startswith("#") or ":" not in stripped:
+                continue
+            key, value = stripped.split(":", 1)
+            env_entries[key.strip()] = value.strip()
+        for key, value in SECRET_VALUES.items():
+            if env_entries.get(key) != value:
+                env_entries[key] = value
+                changed = True
+        if changed:
+            new_block = ["env:\n"]
+            new_block.extend(f"  {k}: {env_entries[k]}\n" for k in env_entries)
+            if block_end >= len(lines) or lines[block_end] != "\n":
+                new_block.append("\n")
+            lines = lines[:root_env_idx] + new_block + lines[block_end:]
+    else:
+        name_idx = next((i for i, line in enumerate(lines) if line.startswith("name:")), None)
+        if name_idx is None:
+            return False
+        insert_idx = name_idx + 1
+        # Remove blank lines directly after name to keep spacing consistent.
+        while insert_idx < len(lines) and lines[insert_idx] == "\n":
+            lines.pop(insert_idx)
+        block = ["env:\n"]
+        block.extend(f"  {key}: {value}\n" for key, value in SECRET_VALUES.items())
+        block.append("\n")
+        lines[insert_idx:insert_idx] = block
+        changed = True
+
+    if changed:
+        path.write_text("".join(lines))
+        print(f"🔧 Patched workflow: {path.name}")
+    return changed
+
+
+def patch_workflows() -> None:
+    wf_dir = Path(".github/workflows")
+    if not wf_dir.exists():
+        return
+    for wf in sorted(wf_dir.glob("*.yml")):
+        patch_workflow(wf)
+
+
+MOTEBAI_ENV_ENTRIES = [
+    "OPENAI_API_KEY=${OPENAI_API_KEY}",
+    "DB_URL=${DB_URL}",
+    "OPENSEARCH_URL=${OPENSEARCH_URL}",
+    "MINIO_ENDPOINT=${MINIO_ENDPOINT}",
+    "MINIO_ROOT_USER=${MINIO_ROOT_USER}",
+    "MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}",
+    "REDIS_URL=${REDIS_URL}",
+    "NEO4J_URI=${NEO4J_URI}",
+    "NEO4J_AUTH=${NEO4J_AUTH}",
+    "CLICKHOUSE_URL=${CLICKHOUSE_URL}",
+]
+
+MOTEBAI_ENV_PATTERN = re.compile(
+    r"(  motebai-api:\n(?:    .*\n)*?    environment:\n)(?P<body>(?:      - .*\n)+)",
+    re.MULTILINE,
+)
+
+
+def patch_docker_compose() -> None:
+    dc_file = Path("docker-compose.yml")
+    if not dc_file.exists():
+        return
+
+    text = dc_file.read_text()
+    original = text
+
+    env_file_snippet = (
+        "  motebai-api:\n    build: .\n    ports:\n      - \"8000:8000\"\n    env_file:\n      - .env\n"
+    )
+    if env_file_snippet not in text:
+        text = text.replace(
+            "  motebai-api:\n    build: .\n    ports:\n      - \"8000:8000\"\n",
+            env_file_snippet,
+            1,
+        )
+
+    match = MOTEBAI_ENV_PATTERN.search(text)
+    if match:
+        body = match.group("body")
+        lines = [line for line in body.splitlines() if line.strip()]
+        existing = {line.strip() for line in lines}
+        for entry in MOTEBAI_ENV_ENTRIES:
+            candidate = f"- {entry}"
+            if candidate not in existing:
+                lines.append(f"      - {entry}")
+                existing.add(candidate)
+        new_body = "\n".join(lines) + "\n"
+        text = text[: match.start("body")] + new_body + text[match.end("body") :]
+
+    text = text.replace(
+        "- MINIO_ROOT_USER=minioadmin", "- MINIO_ROOT_USER=${MINIO_ROOT_USER}"
+    )
+    text = text.replace(
+        "- MINIO_ROOT_PASSWORD=minioadmin",
+        "- MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}",
+    )
+
+    if "    env_file:\n      - .env\n      - /opt/veritas/.env.neo4j" not in text:
+        text = text.replace(
+            "    env_file:\n      - /opt/veritas/.env.neo4j",
+            "    env_file:\n      - .env\n      - /opt/veritas/.env.neo4j",
+        )
+
+    text = text.replace(
+        "- NEO4J_AUTH=${NEO4J_USER}:${NEO4J_PASSWORD}", "- NEO4J_AUTH=${NEO4J_AUTH}"
+    )
+
+    if text != original:
+        dc_file.write_text(text)
+        print("🔧 Patched docker-compose.yml")
+
+
+def patch_readme() -> None:
+    readme = Path("README.md")
+    if not readme.exists():
+        return
+    contents = readme.read_text()
+    if "Environment Setup" not in contents:
+        readme.write_text(contents.rstrip() + "\n\n" + README_SECTION.strip() + "\n")
+        print("📖 Updated README.md")
+
+
+if __name__ == "__main__":
+    write_env_example()
+    patch_workflows()
+    patch_docker_compose()
+    patch_readme()


### PR DESCRIPTION
## Summary
- add a helper script that standardises environment secrets across the repo and regenerates `.env.example`
- inject shared secret variables into the GitHub workflows and document the environment setup in the README
- update `docker-compose.yml` to load values from `.env` for the API, Neo4j, and MinIO services

## Testing
- python scripts/generate_env_and_patch_workflows.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1d075db88320a0ffebd5e4ae286e