### PR TITLE
Adopt provided environment automation script and docker compose layout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,83 +1,10 @@
-# Top-TieR Global HUB AI - Environment Configuration
-# Copy this file to .env and modify the values as needed
-
-# API Server Configuration
-API_HOST=0.0.0.0
-API_PORT=8000
-DEBUG=false
-
-# Application Settings
-APP_NAME=Top-TieR-Global-HUB-AI
-APP_VERSION=2.0.0
-ENVIRONMENT=production
-
-# Database Configuration (if using database)
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/app_db
-REDIS_URL=redis://localhost:6379/0
-
-# Neo4j Graph Database Configuration
-NEO4J_URL=bolt://localhost:7687
-NEO4J_USER=neo4j
-NEO4J_PASSWORD=password
-
-# MinIO Object Storage Configuration
-MINIO_ENDPOINT=http://localhost:9000
-MINIO_ACCESS_KEY=minioadmin
-MINIO_SECRET_KEY=minioadmin
-MINIO_BUCKET_NAME=osint-data
-MINIO_SECURE=false
-
-# OpenSearch Configuration
-OPENSEARCH_HOST=localhost
-OPENSEARCH_PORT=9200
-OPENSEARCH_SCHEME=http
-OPENSEARCH_INDEX_PREFIX=osint
-
-# Security Settings
-# SECRET_KEY=your-secret-key-here
-# JWT_SECRET=your-jwt-secret-here
-
-# External API Keys (for OSINT data sources)
-# OSINT_API_KEY=your-osint-api-key
-# SOCIAL_MEDIA_API_KEY=your-social-media-api-key
-# OPENAI_API_KEY=your-openai-api-key
-
-# Logging Configuration
-LOG_LEVEL=INFO
-LOG_FORMAT=json
-
-# Rate Limiting
-RATE_LIMIT_REQUESTS=100
-RATE_LIMIT_WINDOW=60
-
-# CORS Settings
-CORS_ORIGINS=["http://localhost:3000", "http://localhost:8080"]
-CORS_METHODS=["GET", "POST", "PUT", "DELETE"]
-CORS_HEADERS=["*"]
-
-# Cache Configuration
-REDIS_URL=redis://localhost:6379/0
-CACHE_TTL=300
-CACHE_PREFIX=osint
-
-# Worker Configuration
-WORKER_PROCESSES=4
-WORKER_TIMEOUT=30
-
-# Data Processing Configuration
-MAX_FILE_SIZE=100MB
-ALLOWED_FILE_TYPES=pdf,txt,json,csv,xml
-DATA_RETENTION_DAYS=365
-
-# Search Configuration
-SEARCH_RESULTS_LIMIT=100
-SEARCH_TIMEOUT=30
-
-# Health Check Configuration
-HEALTH_CHECK_INTERVAL=30
-HEALTH_CHECK_TIMEOUT=10
-
-# Monitoring Configuration
-ENABLE_METRICS=true
-METRICS_PORT=9090
-METRICS_PATH=/metrics
+OPENAI_API_KEY=sk-...
+DB_URL=postgresql://postgres:motebai@postgres:5432/motebai
+OPENSEARCH_URL=http://opensearch:9200
+MINIO_ENDPOINT=http://minio:9000
+MINIO_ROOT_USER=motebai
+MINIO_ROOT_PASSWORD=motebai123
+REDIS_URL=redis://redis:6379
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_AUTH=neo4j/motebai
+CLICKHOUSE_URL=http://clickhouse:8123

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,17 @@
 name: CI
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   push:
     branches: [ main, master ]

--- a/.github/workflows/Immutable-Release.yml
+++ b/.github/workflows/Immutable-Release.yml
@@ -10,6 +10,16 @@ permissions:
 
 env:
   IMAGE_NAME: veritas-console
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
 
 jobs:
   build-release:

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -1,4 +1,17 @@
 name: Auto Assign Reviewer
+
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   pull_request:
     types: [opened, reopened, ready_for_review]

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,5 +1,17 @@
 name: Repository Hygiene - Close Old Issues & PRs
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,18 @@
 ---
 name: "CodeQL"
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 'on':
   push:
     branches: ["main", "master"]

--- a/.github/workflows/comment-on-pr6.yml
+++ b/.github/workflows/comment-on-pr6.yml
@@ -1,4 +1,17 @@
-name: Comment on PR #6  
+name: Comment on PR #6
+
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/context-collector.yml
+++ b/.github/workflows/context-collector.yml
@@ -1,5 +1,17 @@
 name: Context Collector
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/daily-readonly-check.yml
+++ b/.github/workflows/daily-readonly-check.yml
@@ -1,6 +1,18 @@
 ---
 name: Daily Readonly Health (Dry-run)
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 "on":
   schedule:
     - cron: "0 7 * * *"   # daily at 07:00 UTC

--- a/.github/workflows/external-api-diagnosis.yml
+++ b/.github/workflows/external-api-diagnosis.yml
@@ -1,5 +1,17 @@
 name: External API Diagnosis
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   schedule:
     - cron: "0 */6 * * *"   # كل 6 ساعات (تقدر تعدل)

--- a/.github/workflows/generate-repo-summary.yml
+++ b/.github/workflows/generate-repo-summary.yml
@@ -1,5 +1,17 @@
 name: Generate repository summary
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   workflow_dispatch: {}
   push:

--- a/.github/workflows/post-merge-validation.yml
+++ b/.github/workflows/post-merge-validation.yml
@@ -1,5 +1,17 @@
 ---
 name: Post-merge Validation (Readonly)
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 "on":
   push:
     branches: [main]

--- a/.github/workflows/post_merge_validation.yml
+++ b/.github/workflows/post_merge_validation.yml
@@ -1,5 +1,17 @@
 name: Post Merge Validation
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   push:
     branches:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,4 +1,17 @@
 name: Sync labels
+
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/veritas-health.yml
+++ b/.github/workflows/veritas-health.yml
@@ -1,5 +1,17 @@
 name: Veritas Nexus • Health (Auto)
 
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+  MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+  MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+  MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+  NEO4J_URI: ${{ secrets.NEO4J_URI }}
+  NEO4J_AUTH: ${{ secrets.NEO4J_AUTH }}
+  CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+
 on:
   push:
     branches: [ main, develop ]

--- a/README.md
+++ b/README.md
@@ -360,3 +360,10 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ---
 
 **Note**: This is an educational OSINT platform. Please use responsibly and in compliance with applicable laws and regulations.
+
+## 🔑 Environment Setup
+
+1. Copy `.env.example` → `.env`
+2. Fill in real values (keys, URLs, passwords).
+3. Add them into GitHub Secrets with the same names.
+4. Docker Compose and GitHub Actions will automatically pick them up.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,171 +1,41 @@
----
 services:
-  # Main API service (motebai-api)
-  motebai-api:
-    build: .
+  core_api:
+    build: ./api_server
+    command: uvicorn api_server:app --host 0.0.0.0 --port 8000
+    volumes:
+      - ./api_server:/app
     ports:
       - "8000:8000"
     environment:
-      - API_HOST=0.0.0.0
-      - API_PORT=8000
-      - ENVIRONMENT=development
-    depends_on:
-      - redis
-      - postgres
-      - neo4j
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - DB_URL=${DB_URL}
+
+  veritas_web:
+    build: ./veritas-web
+    command: uvicorn app:app --host 0.0.0.0 --port 8080
     volumes:
-      - .:/app
-    healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:8000/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
-
-  # Redis for caching
-  redis:
-    image: redis:7-alpine
+      - ./veritas-web:/app
     ports:
-      - "6379:6379"
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+      - "8080:8080"
 
-  # PostgreSQL for data storage
-  postgres:
-    image: postgres:15-alpine
-    ports:
-      - "5432:5432"
-    environment:
-      - POSTGRES_DB=app_db
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-  # Neo4j graph database for OSINT data
   neo4j:
     image: neo4j:5
     ports:
       - "7474:7474"
       - "7687:7687"
-    env_file:
-      - /opt/veritas/.env.neo4j
     environment:
-      - NEO4J_dbms_security_auth__enabled=true
-      - NEO4J_AUTH=${NEO4J_USER}:${NEO4J_PASSWORD}
+      # إمّا تستخدم AUTH مباشرة:
+      - NEO4J_AUTH=neo4j/motebai
+      # أو ترجّع المتغيرين (أكثر وضوحًا):
+      # - NEO4J_USER=neo4j
+      # - NEO4J_PASSWORD=motebai
     volumes:
       - neo4j-data:/data
     healthcheck:
-      test: ["CMD-SHELL", "cypher-shell -u \"$NEO4J_USER\" -p \"$NEO4J_PASSWORD\" 'RETURN 1' || exit 1"]
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p motebai 'RETURN 1;' || exit 1"]
       interval: 10s
       timeout: 5s
-      retries: 10
-      start_period: 20s
-
-  # MinIO - S3-compatible object storage
-  minio:
-    image: minio/minio:latest
-    ports:
-      - "9000:9000"
-      - "9001:9001"
-    environment:
-      - MINIO_ROOT_USER=minioadmin
-      - MINIO_ROOT_PASSWORD=minioadmin
-      - MINIO_SERVER_URL=http://localhost:9000
-      - MINIO_BROWSER_REDIRECT_URL=http://localhost:9001
-    command: server /data --console-address ":9001"
-    volumes:
-      - minio_data:/data
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 20s
-
-  # OpenSearch - Distributed search and analytics engine
-  opensearch:
-    image: opensearchproject/opensearch:2.11.0
-    ports:
-      - "9200:9200"
-      - "9300:9300"
-    environment:
-      - discovery.type=single-node
-      - bootstrap.memory_lock=true
-      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
-      - "DISABLE_INSTALL_DEMO_CONFIG=true"
-      - "DISABLE_SECURITY_PLUGIN=true"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-      nofile:
-        soft: 65536
-        hard: 65536
-    volumes:
-      - opensearch_data:/usr/share/opensearch/data
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9200/_cluster/health || exit 1"]
-      interval: 30s
-      timeout: 10s
       retries: 5
-      start_period: 30s
-
-  # OpenSearch Dashboards (Optional)
-  opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:2.11.0
-    ports:
-      - "5601:5601"
-    environment:
-      - OPENSEARCH_HOSTS=http://opensearch:9200
-      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"
-    depends_on:
-      opensearch:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:5601/api/status || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 60s
-    profiles:
-      - dashboards  # Optional profile - start with: docker compose --profile dashboards up
-
-  # Veritas Mini-Web Service (Optional - enable manually)
-  veritas-web:
-    build: ./veritas-web
-    ports:
-      - "8080:8080"
-    env_file:
-      - /opt/veritas/.env.neo4j
-    environment:
-      - NODE_ENV=production
-    depends_on:
-      neo4j:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
-    profiles:
-      - mini-web  # Optional profile - start with: docker compose --profile mini-web up
 
 volumes:
-  postgres_data:
   neo4j-data:
-  minio_data:
-  opensearch_data:
-
-networks:
-  default:
-    name: top-tier-hub-network

--- a/scripts/generate_env_and_patch_workflows.py
+++ b/scripts/generate_env_and_patch_workflows.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Script for Codex:
+- Generates a .env.example file with all required environment variables.
+- Patches all GitHub workflows in .github/workflows/ to inject secrets automatically.
+- Updates docker-compose.yml to use env variables.
+- Appends an "Environment Setup" section in README.md if not present.
+"""
+
+import os
+import re
+import yaml
+from pathlib import Path
+
+# --- Step 1: Generate .env.example ---
+env_vars = {
+    "OPENAI_API_KEY": "sk-...",
+    "DB_URL": "postgresql://postgres:motebai@postgres:5432/motebai",
+    "OPENSEARCH_URL": "http://opensearch:9200",
+    "MINIO_ENDPOINT": "http://minio:9000",
+    "MINIO_ROOT_USER": "motebai",
+    "MINIO_ROOT_PASSWORD": "motebai123",
+    "REDIS_URL": "redis://redis:6379",
+    "NEO4J_URI": "bolt://neo4j:7687",
+    "NEO4J_AUTH": "neo4j/motebai",
+    "CLICKHOUSE_URL": "http://clickhouse:8123",
+}
+
+env_file = Path(".env.example")
+with env_file.open("w") as f:
+    for k, v in env_vars.items():
+        f.write(f"{k}={v}\n")
+print("✅ Generated .env.example")
+
+# --- Step 2: Patch workflows ---
+wf_dir = Path(".github/workflows")
+if wf_dir.exists():
+    for wf in wf_dir.glob("*.yml"):
+        data = yaml.safe_load(wf.read_text())
+        # inject env if not present
+        if "env" not in data:
+            data["env"] = {}
+        for k in env_vars:
+            data["env"][k] = f"${{{{ secrets.{k} }}}}"
+        wf.write_text(yaml.dump(data, sort_keys=False))
+        print(f"🔧 Patched workflow: {wf.name}")
+
+# --- Step 3: Patch docker-compose.yml ---
+dc_file = Path("docker-compose.yml")
+if dc_file.exists():
+    content = dc_file.read_text()
+    for k in env_vars:
+        if k in content:
+            continue
+        # replace hardcoded values
+        content = re.sub(r"(motebai123|motebai|postgres|neo4j/motebai)", f"${{{k}}}", content)
+    dc_file.write_text(content)
+    print("🔧 Patched docker-compose.yml")
+
+# --- Step 4: Update README.md ---
+readme = Path("README.md")
+section = """
+## 🔑 Environment Setup
+
+1. Copy `.env.example` → `.env`
+2. Fill in real values (keys, URLs, passwords).
+3. Add them into GitHub Secrets with the same names.
+4. Docker Compose and GitHub Actions will automatically pick them up.
+"""
+if readme.exists():
+    text = readme.read_text()
+    if "Environment Setup" not in text:
+        with readme.open("a") as f:
+            f.write(section)
+        print("📖 Updated README.md")


### PR DESCRIPTION
## Summary
- replace the helper script with the provided Codex automation for regenerating the env example, patching workflows, docker compose, and README
- reshape docker-compose.yml to the requested core_api, veritas_web, and neo4j services layout using the documented environment variables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd1d075db88320a0ffebd5e4ae286e