### PR TITLE
Add bootstrap endpoint for committee service

### DIFF
--- a/committee_service/__init__.py
+++ b/committee_service/__init__.py
@@ -1,0 +1,28 @@
+"""Committee service FastAPI application."""
+from .main import (
+    app,
+    api_apply_decision,
+    api_ingest,
+    api_rag_query,
+    apply_rule,
+    bootstrap_example,
+    db_conn,
+    ingest_committee_document,
+    rag_query,
+    reference_guard,
+    sha1_of_text,
+)
+
+__all__ = [
+    "app",
+    "api_apply_decision",
+    "api_ingest",
+    "api_rag_query",
+    "apply_rule",
+    "bootstrap_example",
+    "db_conn",
+    "ingest_committee_document",
+    "rag_query",
+    "reference_guard",
+    "sha1_of_text",
+]

--- a/committee_service/main.py
+++ b/committee_service/main.py
@@ -1,32 +1,24 @@
 #!/usr/bin/env python3
-"""
-committee_service.py
+"""FastAPI application for the Expert Committee service."""
 
-Unified demo service for handling Expert Committee (Council of Ministers) documents:
-- Ingestion (PDF/HTML → JSON)
-- Storage in Postgres
-- RAG search
-- Reference guard
-- Decision engine
-- FastAPI endpoints
-"""
-
-import os
-import json
 import hashlib
+import os
 from typing import Any, Dict, List, Optional
 
-import psycopg2
 from fastapi import FastAPI, Query
+from psycopg2 import connect
+from psycopg2.extensions import connection
+from psycopg2.extras import Json
 
 # ==========
 # إعداد الاتصال بقاعدة البيانات
 # ==========
-DB_URL = os.getenv("DB_URL", "postgresql://postgres:motebai@localhost:5432/motebai")
+DB_URL = os.getenv("DB_URL", "postgresql://postgres:motebai@postgres:5432/motebai")
 
 
-def db_conn():
-    return psycopg2.connect(DB_URL)
+def db_conn() -> connection:
+    """Create a new psycopg2 connection using the configured database URL."""
+    return connect(DB_URL)
 
 
 # ==========
@@ -37,7 +29,7 @@ def sha1_of_text(text: str) -> str:
 
 
 def ingest_committee_document(title: str, content: str, source_url: Optional[str] = None) -> int:
-    """Save committee document into Postgres rag.documents + rag.chunks"""
+    """Save a committee document into ``rag.documents`` with basic chunking."""
     with db_conn() as conn, conn.cursor() as cur:
         sha1 = sha1_of_text(content)
         cur.execute(
@@ -46,7 +38,7 @@ def ingest_committee_document(title: str, content: str, source_url: Optional[str
             VALUES (%s, %s, %s, 'ar', now(), %s)
             RETURNING id
             """,
-            (title, source_url, sha1, json.dumps({"source": "committee"})),
+            (title, source_url, sha1, Json({"source": "committee"})),
         )
         doc_id = cur.fetchone()[0]
 
@@ -58,7 +50,7 @@ def ingest_committee_document(title: str, content: str, source_url: Optional[str
                 INSERT INTO rag.chunks(document_id, chunk_no, content, meta)
                 VALUES (%s, %s, %s, %s)
                 """,
-                (doc_id, i // 500, chunk, json.dumps({"len": len(chunk)})),
+                (doc_id, i // 500, chunk, Json({"len": len(chunk)})),
             )
         conn.commit()
     return doc_id
@@ -111,19 +103,57 @@ def apply_rule(transaction: Dict[str, Any]) -> Dict[str, Any]:
 app = FastAPI(title="Expert Committee Service")
 
 
+@app.post("/bootstrap")
+def bootstrap_example() -> Dict[str, Any]:
+    """Insert a sample document with two chunks to validate Postgres connectivity."""
+    conn = connect(DB_URL)
+    cur = conn.cursor()
+
+    cur.execute(
+        """
+        INSERT INTO rag.documents (title, source_url, lang, meta)
+        VALUES (%s, %s, %s, %s)
+        RETURNING id
+        """,
+        ("وثيقة تجريبية", "http://example.com/test", "ar", Json({"bootstrap": True})),
+    )
+    doc_id = cur.fetchone()[0]
+
+    chunks: List[tuple[int, int, str, Dict[str, str]]] = [
+        (doc_id, 1, "هذا محتوى الفقرة الأولى.", {"note": "اختبار"}),
+        (doc_id, 2, "هذا محتوى الفقرة الثانية.", {"note": "اختبار"}),
+    ]
+    for chunk_doc_id, chunk_no, content, meta in chunks:
+        cur.execute(
+            """
+            INSERT INTO rag.chunks (document_id, chunk_no, content, meta)
+            VALUES (%s, %s, %s, %s)
+            """,
+            (chunk_doc_id, chunk_no, content, Json(meta)),
+        )
+
+    conn.commit()
+    cur.close()
+    conn.close()
+
+    return {"message": "✅ تم إدخال وثيقة تجريبية مع قطعها", "document_id": doc_id}
+
+
 @app.post("/v1/ingest")
-def api_ingest(title: str, content: str, source_url: Optional[str] = None):
+def api_ingest(title: str, content: str, source_url: Optional[str] = None) -> Dict[str, Any]:
     doc_id = ingest_committee_document(title, content, source_url)
     return {"status": "ok", "doc_id": doc_id}
 
 
 @app.get("/v1/rag/query")
-def api_rag_query(q: str = Query(..., description="Keyword to search in committee docs")):
+def api_rag_query(
+    q: str = Query(..., description="Keyword to search in committee docs"),
+) -> Dict[str, Any]:
     refs = rag_query(q)
     answer = f"وجدت {len(refs)} مقطع يحتوي على '{q}'."
     return {"answer": reference_guard(answer, refs), "refs": refs}
 
 
 @app.post("/v1/decision/apply")
-def api_apply_decision(transaction: Dict[str, Any]):
+def api_apply_decision(transaction: Dict[str, Any]) -> Dict[str, Any]:
     return apply_rule(transaction)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi>=0.104.1
 uvicorn[standard]>=0.24.0
 pydantic>=2.5.0
 python-multipart>=0.0.6
-psycopg2-binary>=2.9.9
+psycopg2-binary>=2.9
 requests==2.32.4
 beautifulsoup4>=4.12.2
 PyMuPDF>=1.23.8


### PR DESCRIPTION
## Summary
- add a /bootstrap endpoint in committee_service/main.py to seed a sample document and chunks for Postgres connectivity testing
- expose the committee service package so the app import path stays stable while continuing to use the Postgres default URL and psycopg2 Json helper
- confirm psycopg2-binary is declared in requirements

## Testing
- python -m pytest tests/

------
https://chatgpt.com/codex/tasks/task_e_68cd63311a188320a6d3dfc79075ee56