### PR TITLE
Add GitHub auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,32 @@
+name: Auto Merge PRs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */6 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup gh CLI
+        run: |
+          gh auth status || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge PRs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prs=$(gh pr list --state open --json number --jq '.[].number')
+          for pr in $prs; do
+            echo "Merging PR #$pr ..."
+            gh pr merge $pr --squash --auto --repo $GITHUB_REPOSITORY || echo "Failed PR #$pr"
+          done


### PR DESCRIPTION
## Summary
- add an auto-merge workflow that can be triggered manually or on a 6-hour schedule
- configure the workflow to prepare the GitHub CLI using `gh auth status` before attempting merges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de14c7c5848320997a4ce44aacf877