### PR TITLE
Add service containers for MySQL, Redis, Neo4j, and ClickHouse adapters

### DIFF
--- a/adapters/python/db_clickhouse/Dockerfile
+++ b/adapters/python/db_clickhouse/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5007"]

--- a/adapters/python/db_clickhouse/main.py
+++ b/adapters/python/db_clickhouse/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+from clickhouse_driver import Client
+import os
+
+CLICKHOUSE_HOST = os.getenv("CLICKHOUSE_HOST", "clickhouse")
+CLICKHOUSE_PORT = int(os.getenv("CLICKHOUSE_PORT", "9000"))
+
+client = Client(host=CLICKHOUSE_HOST, port=CLICKHOUSE_PORT)
+
+app = FastAPI(title="LexCode ClickHouse Service")
+
+
+@app.get("/health")
+def health():
+    try:
+        version = client.execute("SELECT version()")
+        version_value = version[0][0] if version else None
+        return {"status": "ok", "db": "clickhouse", "version": version_value}
+    except Exception as exc:
+        return {"error": str(exc)}

--- a/adapters/python/db_clickhouse/requirements.txt
+++ b/adapters/python/db_clickhouse/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+clickhouse-driver

--- a/adapters/python/db_mysql/Dockerfile
+++ b/adapters/python/db_mysql/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN apt-get update && apt-get install -y default-libmysqlclient-dev gcc \
+    && pip install --no-cache-dir -r requirements.txt \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5004"]

--- a/adapters/python/db_mysql/database.py
+++ b/adapters/python/db_mysql/database.py
@@ -1,0 +1,9 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+import os
+
+MYSQL_URL = os.getenv("MYSQL_URL", "mysql://root:password@mysql:3306/lexcode")
+
+engine = create_engine(MYSQL_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/adapters/python/db_mysql/main.py
+++ b/adapters/python/db_mysql/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI, Depends
+from sqlalchemy.orm import Session
+
+import database
+
+app = FastAPI(title="LexCode MySQL Service")
+
+
+@app.get("/health")
+def health(db: Session = Depends(database.SessionLocal)):
+    try:
+        conn = db.connection()
+        conn.close()
+        return {"status": "ok", "db": "mysql"}
+    except Exception as exc:
+        return {"error": str(exc)}

--- a/adapters/python/db_mysql/requirements.txt
+++ b/adapters/python/db_mysql/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+mysqlclient
+sqlalchemy

--- a/adapters/python/db_neo4j/Dockerfile
+++ b/adapters/python/db_neo4j/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5006"]

--- a/adapters/python/db_neo4j/main.py
+++ b/adapters/python/db_neo4j/main.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI
+from neo4j import GraphDatabase
+import os
+
+NEO4J_URI = os.getenv("NEO4J_URI", "bolt://neo4j:7687")
+NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
+NEO4J_PASS = os.getenv("NEO4J_PASS", "password")
+
+driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASS))
+
+app = FastAPI(title="LexCode Neo4j Service")
+
+
+@app.get("/health")
+def health():
+    try:
+        with driver.session() as session:
+            result = session.run("RETURN 1 as ok")
+            record = result.single()
+            return {"status": "ok", "db": "neo4j", "result": record["ok"] if record else None}
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+@app.post("/add")
+def add_node(label: str, name: str):
+    with driver.session() as session:
+        session.run(f"CREATE (n:{label} {{name:$name}})", name=name)
+    return {"added": {"label": label, "name": name}}

--- a/adapters/python/db_neo4j/requirements.txt
+++ b/adapters/python/db_neo4j/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+neo4j

--- a/adapters/python/db_redis/Dockerfile
+++ b/adapters/python/db_redis/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5005"]

--- a/adapters/python/db_redis/main.py
+++ b/adapters/python/db_redis/main.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI
+import os
+import redis
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
+client = redis.Redis.from_url(REDIS_URL)
+
+app = FastAPI(title="LexCode Redis Service")
+
+
+@app.get("/health")
+def health():
+    try:
+        pong = client.ping()
+        return {"status": "ok", "db": "redis", "ping": pong}
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+@app.post("/set/{key}")
+def set_key(key: str, value: str):
+    client.set(key, value)
+    return {"key": key, "value": value}
+
+
+@app.get("/get/{key}")
+def get_key(key: str):
+    val = client.get(key)
+    return {"key": key, "value": val.decode() if isinstance(val, bytes) else None}

--- a/adapters/python/db_redis/requirements.txt
+++ b/adapters/python/db_redis/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,59 @@ services:
     depends_on: [core]
     environment:
       CORE_URL: ${CORE_URL:-http://core:8080}
+
+  db_mysql:
+    build: ./adapters/python/db_mysql
+    ports: ["5004:5004"]
+    environment:
+      - MYSQL_URL=mysql://root:password@mysql:3306/lexcode
+    depends_on: [mysql]
+
+  mysql:
+    image: mysql:8
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: lexcode
+    ports: ["3306:3306"]
+
+  db_redis:
+    build: ./adapters/python/db_redis
+    ports: ["5005:5005"]
+    environment:
+      - REDIS_URL=redis://redis:6379/0
+    depends_on: [redis]
+
+  redis:
+    image: redis:7
+    restart: always
+    ports: ["6379:6379"]
+
+  db_neo4j:
+    build: ./adapters/python/db_neo4j
+    ports: ["5006:5006"]
+    environment:
+      - NEO4J_URI=bolt://neo4j:7687
+      - NEO4J_USER=neo4j
+      - NEO4J_PASS=password
+    depends_on: [neo4j]
+
+  neo4j:
+    image: neo4j:5
+    restart: always
+    environment:
+      - NEO4J_AUTH=neo4j/password
+    ports: ["7474:7474", "7687:7687"]
+
+  db_clickhouse:
+    build: ./adapters/python/db_clickhouse
+    ports: ["5007:5007"]
+    environment:
+      - CLICKHOUSE_HOST=clickhouse
+      - CLICKHOUSE_PORT=9000
+    depends_on: [clickhouse]
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:23
+    restart: always
+    ports: ["9000:9000", "8123:8123"]


### PR DESCRIPTION
## Summary
- add FastAPI-based adapters for MySQL, Redis, Neo4j, and ClickHouse under `adapters/python`
- include Dockerfiles and service requirements to build each database adapter
- extend `docker-compose.yml` with database services and backing data stores

## Testing
- not run (containerized services not started)


------
https://chatgpt.com/codex/tasks/task_e_68deb8356f8883208979f060eae22965