### PR TITLE
Add Codex autopilot GitHub Actions workflow

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,19 @@
+name: Codex Autopilot
+
+on:
+  push:
+  schedule:
+    - cron: "0 */6 * * *"
+
+jobs:
+  autopilot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Setup Codex
+        run: |
+          codex auth github --token ${{ secrets.LEXCODE_GITHUB_TOKEN }}
+          codex connect github --repo MOTEB1989/Top-TieR-Global-HUB-AI
+          codex status github --repo MOTEB1989/Top-TieR-Global-HUB-AI


### PR DESCRIPTION
## Summary
- add a Codex Autopilot workflow that authenticates using the stored GitHub token
- connect the repository and report Codex status on every push and on a six-hour schedule

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68debe90cd4883208c4df7fe7646d75a