### PR TITLE
Add GitHub repo status endpoint

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -34,6 +34,38 @@ app.post('/v1/embed', async (req, res) => {
   }
 });
 
+/* ---------------- Repo Status (GitHub API) ---------------- */
+app.get('/v1/repo/status', async (_req, res) => {
+  try {
+    const GITHUB_TOKEN = process.env.LEXCODE_GITHUB_TOKEN;
+    if (!GITHUB_TOKEN) {
+      return res.status(400).json({ error: 'Missing LEXCODE_GITHUB_TOKEN in environment' });
+    }
+
+    const owner = 'MOTEB1989';
+    const repo = 'Top-TieR-Global-HUB-AI';
+
+    const headers = { Authorization: `token ${GITHUB_TOKEN}`, 'User-Agent': 'LexCode-Gateway' };
+
+    const commits = await axios.get(`https://api.github.com/repos/${owner}/${repo}/commits`, { headers });
+    const branches = await axios.get(`https://api.github.com/repos/${owner}/${repo}/branches`, { headers });
+    const pulls = await axios.get(`https://api.github.com/repos/${owner}/${repo}/pulls?state=open`, { headers });
+
+    res.json({
+      repo: `${owner}/${repo}`,
+      latest_commit: {
+        sha: commits.data[0].sha,
+        message: commits.data[0].commit.message,
+        author: commits.data[0].commit.author,
+      },
+      branches: branches.data.map((b: any) => b.name),
+      open_prs: pulls.data.map((p: any) => ({ number: p.number, title: p.title, user: p.user.login })),
+    });
+  } catch (e: any) {
+    res.status(500).json({ error: e?.message || 'github_status_failed' });
+  }
+});
+
 app.listen(PORT, () => {
   console.log(`LexCode API on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- add a `/v1/repo/status` gateway endpoint that proxies GitHub API data for the Top-TieR repository
- include latest commit, branches, and open PRs in the returned payload

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68debef1edfc83208ba7950977440642