### PR TITLE
Add knowledge base API service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,12 @@ services:
     depends_on: [core]
     environment:
       CORE_URL: ${CORE_URL:-http://core:8080}
+  kb_api:
+    build: ./services/kb_api
+    ports: ["5100:5100"]
+    environment:
+      - KB_PATH=.kb_store
+      - KB_COLLECTION=lexcode_kb
+      - EMB_MODEL=sentence-transformers/all-MiniLM-L6-v2
+    volumes:
+      - ./.kb_store:/app/.kb_store

--- a/services/kb_api/Dockerfile
+++ b/services/kb_api/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY . .
+EXPOSE 5100
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5100"]

--- a/services/kb_api/main.py
+++ b/services/kb_api/main.py
@@ -1,0 +1,52 @@
+from fastapi import FastAPI, Query, HTTPException
+import chromadb
+from chromadb.config import Settings
+from sentence_transformers import SentenceTransformer
+import os
+
+app = FastAPI(title="LexCode KB API")
+
+DB_PATH = os.getenv("KB_PATH", ".kb_store")
+COLLECTION_NAME = os.getenv("KB_COLLECTION", "lexcode_kb")
+MODEL_NAME = os.getenv("EMB_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
+
+# init chroma + model
+client = chromadb.PersistentClient(path=DB_PATH, settings=Settings(allow_reset=False))
+coll = client.get_or_create_collection(name=COLLECTION_NAME, metadata={"hnsw:space": "cosine"})
+model = SentenceTransformer(MODEL_NAME)
+
+@app.get("/health")
+def health():
+    return {"status": "ok", "collection": COLLECTION_NAME, "db_path": DB_PATH}
+
+@app.get("/search")
+def search(q: str = Query(..., description="Query text"), top_k: int = 5):
+    if not q.strip():
+        raise HTTPException(status_code=400, detail="Query cannot be empty")
+    emb = model.encode([q], normalize_embeddings=True).tolist()
+    results = coll.query(query_embeddings=emb, n_results=top_k)
+    docs = [
+        {
+            "id": i,
+            "text": d,
+            "score": s,
+            "path": m.get("path"),
+            "chunk": m.get("chunk")
+        }
+        for i, d, s, m in zip(results["ids"][0], results["documents"][0], results["distances"][0], results["metadatas"][0])
+    ]
+    return {"query": q, "results": docs}
+
+@app.get("/ask")
+def ask(q: str = Query(...), top_k: int = 5):
+    """
+    استرجاع + دمج (RAG) — يرجع أفضل مقاطع مرتبطة بالسؤال.
+    يمكن لاحقًا تمريرها لنموذج لغة عبر Gateway.
+    """
+    search_results = search(q, top_k)
+    context = "\n\n".join([r["text"] for r in search_results["results"]])
+    return {
+        "query": q,
+        "context": context,
+        "results": search_results["results"]
+    }

--- a/services/kb_api/requirements.txt
+++ b/services/kb_api/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+chromadb
+sentence-transformers


### PR DESCRIPTION
## Summary
- add a dedicated FastAPI knowledge base service backed by ChromaDB
- include container image definition and requirements for the knowledge base API
- wire the new kb_api service into docker-compose with environment, ports, and volume

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dec43978c08320a734c1d86116e979