### PR TITLE
Add knowledge base dashboard page

### DIFF
--- a/dashboard/components/Navbar.tsx
+++ b/dashboard/components/Navbar.tsx
@@ -1,0 +1,8 @@
+export default function Navbar() {
+  return (
+    <header className="border-b bg-white px-6 py-4 flex items-center justify-between">
+      <h1 className="text-lg font-semibold">Top-TieR Global HUB AI</h1>
+      <span className="text-sm text-gray-500">Dashboard</span>
+    </header>
+  );
+}

--- a/dashboard/components/Sidebar.tsx
+++ b/dashboard/components/Sidebar.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+const items = [
+  { href: "/", label: "Overview" },
+  { href: "/databases", label: "Databases" },
+  { href: "/rag", label: "RAG" },
+  { href: "/models", label: "Models" },
+  { href: "/security", label: "Security" },
+  { href: "/logs", label: "Logs" },
+  { href: "/repo", label: "Repo Status" },
+  { href: "/kb", label: "Knowledge Base" },
+];
+
+export default function Sidebar() {
+  const router = useRouter();
+
+  return (
+    <aside className="w-64 min-h-screen border-r bg-gray-50 p-4 space-y-4">
+      <h2 className="text-lg font-semibold">Top-TieR Dashboard</h2>
+      <nav className="space-y-2">
+        {items.map(item => {
+          const active = router.pathname === item.href;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`block rounded px-3 py-2 text-sm transition-colors ${
+                active ? "bg-black text-white" : "text-gray-700 hover:bg-gray-200"
+              }`}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/dashboard/components/Table.tsx
+++ b/dashboard/components/Table.tsx
@@ -1,0 +1,45 @@
+import { ReactNode } from "react";
+
+type TableRow = Record<string, ReactNode>;
+
+type TableProps = {
+  columns: string[];
+  rows: TableRow[];
+};
+
+export default function Table({ columns, rows }: TableProps) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200 text-sm">
+        <thead className="bg-gray-50">
+          <tr>
+            {columns.map(column => (
+              <th key={column} className="px-4 py-2 text-left font-medium text-gray-600 uppercase tracking-wider">
+                {column}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200 bg-white">
+          {rows.length === 0 ? (
+            <tr>
+              <td className="px-4 py-3 text-center text-gray-500" colSpan={columns.length}>
+                No results yet.
+              </td>
+            </tr>
+          ) : (
+            rows.map((row, rowIndex) => (
+              <tr key={rowIndex} className="hover:bg-gray-50">
+                {columns.map(column => (
+                  <td key={column} className="px-4 py-2 text-gray-700 align-top whitespace-pre-wrap">
+                    {row[column] as ReactNode}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/dashboard/pages/kb.tsx
+++ b/dashboard/pages/kb.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import axios from "axios";
+import Sidebar from "../components/Sidebar";
+import Navbar from "../components/Navbar";
+import Table from "../components/Table";
+
+export default function KB() {
+  const GW = process.env.NEXT_PUBLIC_GATEWAY_URL || process.env.GATEWAY_URL || "http://localhost:3000";
+
+  const [query, setQuery] = useState("ما هي FastAPI؟");
+  const [mode, setMode] = useState<"search" | "ask">("search");
+  const [resp, setResp] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+
+  const run = async () => {
+    setLoading(true);
+    try {
+      const r = await axios.post(`${GW}/v1/kb/${mode}`, { query, top_k: 5 });
+      setResp(r.data);
+    } catch (e: any) {
+      setResp({ error: e.message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex">
+      <Sidebar />
+      <div className="flex-1">
+        <Navbar />
+        <div className="p-6 space-y-6">
+          <h1 className="text-xl font-semibold">📚 Knowledge Base</h1>
+
+          <div className="bg-white border rounded p-4 space-y-4">
+            <div className="flex gap-3">
+              <select className="border rounded px-2 py-1" value={mode} onChange={e => setMode(e.target.value as any)}>
+                <option value="search">Search</option>
+                <option value="ask">Ask (RAG)</option>
+              </select>
+              <button
+                onClick={run}
+                disabled={loading}
+                className="px-3 py-1 rounded bg-black text-white"
+              >
+                {loading ? "Loading..." : "Run"}
+              </button>
+            </div>
+            <input
+              className="w-full border rounded p-2"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder="اكتب استعلامك هنا..."
+            />
+          </div>
+
+          {resp && (
+            <div className="bg-white border rounded p-4">
+              <h2 className="font-semibold mb-2">Results</h2>
+
+              {resp.error && <p className="text-red-600">Error: {resp.error}</p>}
+
+              {mode === "search" && resp.results && (
+                <Table
+                  columns={["id", "path", "chunk", "score"]}
+                  rows={resp.results[0]?.map((_: any, i: number) => ({
+                    id: resp.results.ids[0][i],
+                    path: resp.results.metadatas[0][i]?.path,
+                    chunk: resp.results.metadatas[0][i]?.chunk,
+                    score: resp.results.distances[0][i]?.toFixed(4),
+                  })) || []}
+                />
+              )}
+
+              {mode === "ask" && (
+                <div className="space-y-2">
+                  <p className="text-gray-700 whitespace-pre-line">{resp.context}</p>
+                  <details className="mt-2">
+                    <summary className="cursor-pointer text-sm text-blue-600">Raw Data</summary>
+                    <pre className="text-xs overflow-auto">{JSON.stringify(resp, null, 2)}</pre>
+                  </details>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a knowledge base dashboard page that can query the gateway search and ask endpoints
- create lightweight dashboard components, including a results table helper
- extend the sidebar navigation with a Knowledge Base entry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dec59220c4832085e9d40784337b2d