### PR TITLE
Add dashboard build assets to docker compose

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,20 @@
+# Stage 1: Build
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+# Stage 2: Run
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY --from=builder /app ./
+
+EXPOSE 3001
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,15 @@ services:
     depends_on: [core]
     environment:
       CORE_URL: ${CORE_URL:-http://core:8080}
+  dashboard:
+    build:
+      context: ./dashboard
+      dockerfile: Dockerfile
+    container_name: dashboard
+    ports:
+      - "3001:3001"
+    environment:
+      - NODE_ENV=production
+    depends_on:
+      - gateway
+      - llm_api


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for the dashboard application
- register the dashboard service in docker-compose so it can be built and run alongside other services

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deccdaee708320b953eb7c252e8be7