### PR TITLE
Add workflow to build and push dashboard Docker image

### DIFF
--- a/.github/workflows/dashboard-docker.yml
+++ b/.github/workflows/dashboard-docker.yml
@@ -1,0 +1,37 @@
+name: Build & Push Dashboard Image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Dashboard image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./dashboard
+          file: ./dashboard/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/dashboard:latest


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build the dashboard Docker image with Buildx
- push the built image to GHCR on pushes to main or manual dispatch

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68decd08e78083209574cbfb7efab2f6