### PR TITLE
Add SwiftUI chat client scaffolding

### DIFF
--- a/LexCodeChat/ChatBubble.swift
+++ b/LexCodeChat/ChatBubble.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct ChatBubble: View {
+    let message: ChatMessage
+
+    var body: some View {
+        HStack {
+            if message.isUser { Spacer() }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(message.text)
+                    .padding()
+                    .background(message.isUser ? Color.blue : Color.gray.opacity(0.2))
+                    .foregroundColor(message.isUser ? .white : .black)
+                    .cornerRadius(16)
+
+                Text(message.timestamp, style: .time)
+                    .font(.caption2)
+                    .foregroundColor(.gray)
+            }
+
+            if !message.isUser { Spacer() }
+        }
+        .padding(message.isUser ? .leading : .trailing, 50)
+        .padding(.vertical, 4)
+    }
+}

--- a/LexCodeChat/ContentView.swift
+++ b/LexCodeChat/ContentView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var messages: [ChatMessage] = []
+    @State private var userInput: String = ""
+
+    var body: some View {
+        VStack {
+            ScrollViewReader { scrollView in
+                ScrollView {
+                    LazyVStack {
+                        ForEach(messages) { msg in
+                            ChatBubble(message: msg)
+                                .id(msg.id)
+                        }
+                    }
+                }
+                .onChange(of: messages.count) { _ in
+                    if let last = messages.last {
+                        withAnimation {
+                            scrollView.scrollTo(last.id, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+
+            HStack {
+                TextField("Type a message...", text: $userInput)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .frame(minHeight: 40)
+
+                Button(action: sendMessage) {
+                    Text("Send")
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                }
+            }
+            .padding()
+        }
+    }
+
+    func sendMessage() {
+        let userMsg = ChatMessage(text: userInput, isUser: true, timestamp: Date())
+        messages.append(userMsg)
+        let query = userInput
+        userInput = ""
+
+        APIService.shared.sendMessage(query) { reply in
+            DispatchQueue.main.async {
+                let botMsg = ChatMessage(text: reply, isUser: false, timestamp: Date())
+                messages.append(botMsg)
+            }
+        }
+    }
+}

--- a/LexCodeChat/LexCodeChatApp.swift
+++ b/LexCodeChat/LexCodeChatApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct LexCodeChatApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/LexCodeChat/Models.swift
+++ b/LexCodeChat/Models.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct ChatMessage: Identifiable {
+    let id = UUID()
+    let text: String
+    let isUser: Bool
+    let timestamp: Date
+}
+
+struct ChatResponse: Decodable {
+    let response: String
+}

--- a/LexCodeChat/Services.swift
+++ b/LexCodeChat/Services.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+class APIService {
+    static let shared = APIService()
+    private init() {}
+
+    let baseURL = "http://localhost:5000/chat"
+
+    func sendMessage(_ message: String, provider: String = "openai", completion: @escaping (String) -> Void) {
+        guard let url = URL(string: baseURL) else {
+            completion("❌ Invalid URL")
+            return
+        }
+
+        let body: [String: Any] = [
+            "message": message,
+            "provider": provider
+        ]
+
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: body) else {
+            completion("❌ Error encoding JSON")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = jsonData
+
+        URLSession.shared.dataTask(with: request) { data, _, error in
+            if let error = error {
+                completion("⚠️ Error: \(error.localizedDescription)")
+                return
+            }
+
+            guard let data = data else {
+                completion("⚠️ No data returned")
+                return
+            }
+
+            if let decoded = try? JSONDecoder().decode(ChatResponse.self, from: data) {
+                completion(decoded.response)
+            } else {
+                completion("⚠️ Failed to decode response")
+            }
+        }.resume()
+    }
+}


### PR DESCRIPTION
## Summary
- add SwiftUI models for chat messages and API responses
- implement a reusable chat bubble view and main content view with message sending support
- include an API service and app entry point to wire up the chat interface

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68decf97fb8883208af766155da043c0