### PR TITLE
Add provider selection UI and include provider in chat requests

### DIFF
--- a/ios-app/ContentView.swift
+++ b/ios-app/ContentView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var messages: [ChatMessage] = []
+    @State private var userInput: String = ""
+    @State private var selectedProvider: String = "openai"
+
+    let providers = ["openai", "hf", "anthropic", "kb"]
+
+    var body: some View {
+        VStack {
+            Picker("Provider", selection: $selectedProvider) {
+                ForEach(providers, id: \.self) { provider in
+                    Text(provider.capitalized).tag(provider)
+                }
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            .padding()
+
+            ScrollViewReader { scrollView in
+                ScrollView {
+                    LazyVStack {
+                        ForEach(messages) { msg in
+                            ChatBubble(message: msg)
+                                .id(msg.id)
+                        }
+                    }
+                }
+                .onChange(of: messages.count) { _ in
+                    if let last = messages.last {
+                        withAnimation {
+                            scrollView.scrollTo(last.id, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+
+            HStack {
+                TextField("Type a message...", text: $userInput)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .frame(minHeight: 40)
+
+                Button(action: sendMessage) {
+                    Text("Send")
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                }
+            }
+            .padding()
+        }
+    }
+
+    func sendMessage() {
+        let userMsg = ChatMessage(text: userInput, isUser: true, timestamp: Date())
+        messages.append(userMsg)
+        let query = userInput
+        userInput = ""
+
+        APIService.shared.sendMessage(query, provider: selectedProvider) { reply in
+            DispatchQueue.main.async {
+                let botMsg = ChatMessage(text: reply, isUser: false, timestamp: Date())
+                messages.append(botMsg)
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ios-app/Services.swift
+++ b/ios-app/Services.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+final class APIService {
+    static let shared = APIService()
+
+    private let baseURL = "http://localhost:5000/api/chat"
+    private init() {}
+
+    func sendMessage(_ message: String, provider: String = "openai", completion: @escaping (String) -> Void) {
+        guard let url = URL(string: baseURL) else {
+            completion("❌ Invalid URL")
+            return
+        }
+
+        let body: [String: Any] = [
+            "message": message,
+            "provider": provider
+        ]
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+        } catch {
+            completion("❌ Failed to encode request body")
+            return
+        }
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion("❌ Network error: \(error.localizedDescription)")
+                return
+            }
+
+            guard let data = data else {
+                completion("❌ Empty response")
+                return
+            }
+
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let reply = json["reply"] as? String {
+                completion(reply)
+            } else if let stringResponse = String(data: data, encoding: .utf8) {
+                completion(stringResponse)
+            } else {
+                completion("❌ Failed to parse response")
+            }
+        }.resume()
+    }
+}


### PR DESCRIPTION
## Summary
- add a segmented picker to the chat interface so the user can choose between available LLM providers
- update the API service to include the selected provider when sending chat requests

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68decfc8c7688320a4a0a7478823cc1a