### PR TITLE
Add provider metadata to chat SwiftUI views

### DIFF
--- a/ios/ChatBubble.swift
+++ b/ios/ChatBubble.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct ChatBubble: View {
+    let message: ChatMessage
+
+    var body: some View {
+        HStack {
+            if message.isUser { Spacer() }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(message.text)
+                    .padding()
+                    .background(message.isUser ? Color.blue : Color.gray.opacity(0.2))
+                    .foregroundColor(message.isUser ? .white : .black)
+                    .cornerRadius(16)
+
+                HStack(spacing: 4) {
+                    Text(message.timestamp, style: .time)
+                        .font(.caption2)
+                        .foregroundColor(.gray)
+
+                    if !message.isUser, let provider = message.provider {
+                        Text("[\(provider.capitalized)]")
+                            .font(.caption2)
+                            .foregroundColor(.purple)
+                    }
+                }
+            }
+
+            if !message.isUser { Spacer() }
+        }
+        .padding(message.isUser ? .leading : .trailing, 50)
+        .padding(.vertical, 4)
+    }
+}
+
+struct ChatBubble_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 12) {
+            ChatBubble(message: ChatMessage(text: "Hello!", isUser: true, timestamp: Date(), provider: nil))
+            ChatBubble(message: ChatMessage(text: "Hi there", isUser: false, timestamp: Date(), provider: "openai"))
+        }
+        .padding()
+    }
+}

--- a/ios/ContentView.swift
+++ b/ios/ContentView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var messages: [ChatMessage] = []
+    @State private var userInput: String = ""
+    @State private var selectedProvider: String = "openai"
+
+    private let providers: [String] = ["openai", "anthropic", "azure"]
+
+    var body: some View {
+        VStack {
+            Picker("Provider", selection: $selectedProvider) {
+                ForEach(providers, id: \.self) { provider in
+                    Text(provider.capitalized)
+                        .tag(provider)
+                }
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            .padding()
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    ForEach(messages) { message in
+                        ChatBubble(message: message)
+                    }
+                }
+                .padding(.horizontal)
+            }
+
+            HStack {
+                TextField("Type your message", text: $userInput)
+                    .textFieldStyle(.roundedBorder)
+
+                Button("Send") {
+                    sendMessage()
+                }
+                .disabled(userInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            .padding()
+        }
+    }
+
+    private func sendMessage() {
+        let trimmed = userInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let userMsg = ChatMessage(
+            text: trimmed,
+            isUser: true,
+            timestamp: Date(),
+            provider: nil
+        )
+
+        messages.append(userMsg)
+        userInput = ""
+
+        APIService.shared.sendMessage(trimmed, provider: selectedProvider) { reply in
+            DispatchQueue.main.async {
+                let botMsg = ChatMessage(
+                    text: reply,
+                    isUser: false,
+                    timestamp: Date(),
+                    provider: selectedProvider
+                )
+                messages.append(botMsg)
+            }
+        }
+    }
+}
+
+final class APIService {
+    static let shared = APIService()
+
+    func sendMessage(_ message: String, provider: String, completion: @escaping (String) -> Void) {
+        // Placeholder implementation.
+        let reply = "Response from \(provider.capitalized): \(message)"
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.3) {
+            completion(reply)
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ios/Models.swift
+++ b/ios/Models.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct ChatMessage: Identifiable {
+    let id = UUID()
+    let text: String
+    let isUser: Bool
+    let timestamp: Date
+    let provider: String?
+}
+
+struct ChatResponse: Decodable {
+    let response: String
+}


### PR DESCRIPTION
## Summary
- add an optional provider field to `ChatMessage` model and keep API response model intact
- render the provider label under bot messages in `ChatBubble`
- update `ContentView` to tag bot responses with the selected provider while leaving user messages without a provider

## Testing
- not run (SwiftUI code only)


------
https://chatgpt.com/codex/tasks/task_e_68ded033c088832092ef35c7e67973c1