### PR TITLE
Add ingress and cluster issuer manifests

### DIFF
--- a/k8s/cluster-issuer.yml
+++ b/k8s/cluster-issuer.yml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+  namespace: cert-manager
+spec:
+  acme:
+    email: admin@lexcode.ai
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -1,0 +1,41 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: lexcode-ingress
+  namespace: lexcode
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  tls:
+    - hosts:
+        - hub.lexcode.ai
+      secretName: lexcode-tls
+  rules:
+    - host: hub.lexcode.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dashboard-svc
+                port:
+                  number: 80
+    - host: api.lexcode.ai
+      http:
+        paths:
+          - path: /chat
+            pathType: Prefix
+            backend:
+              service:
+                name: gateway-svc
+                port:
+                  number: 5000
+          - path: /runner
+            pathType: Prefix
+            backend:
+              service:
+                name: runner-svc
+                port:
+                  number: 8000


### PR DESCRIPTION
## Summary
- add a cert-manager ClusterIssuer manifest configured for Let’s Encrypt production
- define an ingress resource exposing the dashboard, gateway, and runner services with TLS

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68ded7d5d0a083209cfdcd6906ae04cc