### PR TITLE
Add Loki and Promtail logging stack to Helm chart

### DIFF
--- a/charts/lexcode/templates/loki-configmap.yaml
+++ b/charts/lexcode/templates/loki-configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.loki.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+data:
+  local-config.yaml: |
+{{- toYaml .Values.loki.config | nindent 4 }}
+{{- end }}

--- a/charts/lexcode/templates/loki-deployment.yaml
+++ b/charts/lexcode/templates/loki-deployment.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.loki.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      containers:
+        - name: loki
+          image: {{ .Values.loki.image }}
+          args:
+            - -config.file=/etc/loki/local-config.yaml
+          ports:
+            - containerPort: {{ .Values.loki.servicePort }}
+          volumeMounts:
+            - name: loki-config
+              mountPath: /etc/loki
+            - name: loki-storage
+              mountPath: /loki
+      volumes:
+        - name: loki-config
+          configMap:
+            name: loki-config
+        - name: loki-storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+spec:
+  ports:
+    - port: {{ .Values.loki.servicePort }}
+      targetPort: {{ .Values.loki.servicePort }}
+      protocol: TCP
+      name: http
+  selector:
+    app: loki
+{{- end }}

--- a/charts/lexcode/templates/promtail-configmap.yaml
+++ b/charts/lexcode/templates/promtail-configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.promtail.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+data:
+  config.yaml: |
+{{- toYaml .Values.promtail.config | nindent 4 }}
+{{- end }}

--- a/charts/lexcode/templates/promtail-daemonset.yaml
+++ b/charts/lexcode/templates/promtail-daemonset.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.promtail.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: promtail
+  template:
+    metadata:
+      labels:
+        app: promtail
+    spec:
+      serviceAccountName: promtail
+      containers:
+        - name: promtail
+          image: {{ .Values.promtail.image }}
+          args:
+            - -config.file=/etc/promtail/config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /etc/promtail
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: promtail-config
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+{{- end }}

--- a/charts/lexcode/templates/promtail-rbac.yaml
+++ b/charts/lexcode/templates/promtail-rbac.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.promtail.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promtail
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: promtail
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - namespaces
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: promtail
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: promtail
+subjects:
+  - kind: ServiceAccount
+    name: promtail
+    namespace: {{ .Values.namespace | default .Release.Namespace }}
+{{- end }}

--- a/charts/lexcode/values.yaml
+++ b/charts/lexcode/values.yaml
@@ -1,0 +1,79 @@
+namespace: lexcode
+
+loki:
+  enabled: true
+  image: grafana/loki:2.9.0
+  servicePort: 3100
+  config:
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9096
+    ingester:
+      lifecycler:
+        address: 127.0.0.1
+        ring:
+          kvstore:
+            store: inmemory
+          replication_factor: 1
+        final_sleep: 0s
+      chunk_idle_period: 5m
+      chunk_retain_period: 30s
+      max_transfer_retries: 0
+    schema_config:
+      configs:
+        - from: 2020-10-15
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: index_
+            period: 24h
+    storage_config:
+      boltdb_shipper:
+        active_index_directory: /loki/index
+        cache_location: /loki/cache
+        shared_store: filesystem
+      filesystem:
+        directory: /loki/chunks
+    compactor:
+      working_directory: /loki/compactor
+      shared_store: filesystem
+    limits_config:
+      retention_period: 168h
+    chunk_store_config:
+      max_look_back_period: 0s
+    table_manager:
+      retention_deletes_enabled: true
+      retention_period: 168h
+
+promtail:
+  enabled: true
+  image: grafana/promtail:2.9.0
+  config:
+    server:
+      http_listen_port: 9080
+      grpc_listen_port: 0
+    positions:
+      filename: /tmp/positions.yaml
+    clients:
+      - url: http://loki:3100/loki/api/v1/push
+    scrape_configs:
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            target_label: app
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+
+grafana:
+  datasources:
+    - name: Prometheus
+      type: prometheus
+      url: http://prometheus:9090
+    - name: Loki
+      type: loki
+      url: http://loki:3100


### PR DESCRIPTION
## Summary
- add default values for Grafana Loki, Promtail, and a Grafana Loki datasource
- add Helm templates for a Loki deployment and service driven by the new values
- add Promtail daemonset, configuration, and RBAC templates to ship pod logs into Loki

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dedda722708320bdd1862cf3dd3eaf