### PR TITLE
docs: document ngrok sharing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,22 @@ OPENAI_BASE_URL=https://api.openai.com/v1  # اختياري
 ```bash
 curl -X POST http://localhost:3000/v1/ai/infer \  -H "Content-Type: application/json" \  -d '{ "messages": [ { "role": "user", "content": "عرّف LexCode في جملة واحدة." } ] }'
 ```
+
+## مشاركة البوابة عبر ngrok
+
+لتوفير بوابة الـ API للآخرين دون فتح المنافذ يدويًا، يمكنك استخدام `ngrok`:
+
+```bash
+ngrok http 3000
+```
+
+ستحصل على رابط عشوائي في كل مرة مثل:
+
+```
+Forwarding  https://7f8a-102-45-33-12.ngrok-free.app -> http://localhost:3000
+```
+
+- عنوان البوابة الخارجي: `https://7f8a-102-45-33-12.ngrok-free.app/`
+- مسار الاستدلال الكامل: `https://7f8a-102-45-33-12.ngrok-free.app/v1/ai/infer`
+
+> **ملاحظة:** الجزء قبل `.ngrok-free.app` يتغيّر مع كل تشغيل للحسابات المجانية. للحصول على نطاق مخصّص ثابت (مثل `https://myapi.ngrok-free.app`)، تحتاج إلى حساب ngrok مدفوع وتفعيل ميزة *Custom Subdomain*.


### PR DESCRIPTION
## Summary
- document how to expose the API gateway via ngrok
- explain that free ngrok URLs change per session and note custom subdomains on paid plans

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee0391fd08320ac10b58b087ee03b