### PR TITLE
Add gateway endpoint for external AI model inference

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,8 @@ app.use(express.json());
 
 const PORT = Number(process.env.API_PORT || 3000);
 const CORE_URL = process.env.CORE_URL || 'http://localhost:8080';
+const EXT_MODEL_URL = process.env.EXT_MODEL_URL || 'https://api.external-llm.com/v1/infer';
+const EXT_API_KEY = process.env.EXT_API_KEY;
 
 app.get('/v1/health', async (_req, res) => {
   try {
@@ -22,6 +24,7 @@ app.get('/v1/health', async (_req, res) => {
 });
 
 const EmbedSchema = z.object({ text: z.string().min(1) });
+const ExternalModelSchema = z.object({ input: z.string().min(1) });
 
 app.post('/v1/embed', async (req, res) => {
   const parsed = EmbedSchema.safeParse(req.body);
@@ -55,5 +58,27 @@ app.post('/v1/ai/infer', async (req, res) => {
     res.json({ provider: 'openai', ...out });
   } catch (e: any) {
     res.status(500).json({ error: e?.message || 'inference_failed' });
+  }
+});
+
+app.post('/v1/ai/other-model', async (req, res) => {
+  const parsed = ExternalModelSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json(parsed.error.format());
+
+  try {
+    const response = await axios.post(
+      EXT_MODEL_URL,
+      { prompt: parsed.data.input },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          ...(EXT_API_KEY ? { Authorization: `Bearer ${EXT_API_KEY}` } : {}),
+        },
+      }
+    );
+    res.json(response.data);
+  } catch (e: any) {
+    const status = e?.response?.status ?? 500;
+    res.status(status).json({ error: e?.message || 'external_inference_failed' });
   }
 });


### PR DESCRIPTION
## Summary
- add configuration for external model endpoint on the API gateway
- proxy /v1/ai/other-model requests to the configured external inference API
- validate request payloads and surface upstream errors to clients

## Testing
- npm run build *(fails: TS18003: No inputs were found in config file '/workspace/Top-TieR-Global-HUB-AI/tsconfig.json')*

------
https://chatgpt.com/codex/tasks/task_e_68dee0f359e483208523493b8769e618