### PR TITLE
Add documentation for knowledge base namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ OPENAI_BASE_URL=https://api.openai.com/v1  # اختياري
 ```bash
 curl -X POST http://localhost:3000/v1/ai/infer \  -H "Content-Type: application/json" \  -d '{ "messages": [ { "role": "user", "content": "عرّف LexCode في جملة واحدة." } ] }'
 ```
+
+## التحقق من ربط Codex ومساحات المعرفة
+
+للتأكد من أن نماذج Codex الخاصة بك تستخدم مساحات المعرفة الصحيحة (مثل `saudi_banks/` و`saudi_nexus/` و`mohsen_gj/`)، راجع الدليل التفصيلي في [`docs/knowledge-base-namespaces.md`](docs/knowledge-base-namespaces.md).

--- a/docs/knowledge-base-namespaces.md
+++ b/docs/knowledge-base-namespaces.md
@@ -1,0 +1,33 @@
+# التحقق من مساحات المعرفة الخاصة بالنماذج
+
+يوضح هذا الدليل كيفية التأكد من أن مستودع `Top-TieR-Global-HUB-AI` مرتبط بخدمة Codex وأن كل نموذج يمتلك مساحة منفصلة في قاعدة المعرفة (Knowledge Base).
+
+## 1. التأكد من حالة Codex
+
+نفِّذ الأمر التالي للتأكد من أن خط أنابيب الإدخال (ingestion pipeline) يعمل وأن المستودع مربوط بخدمة Codex:
+
+```bash
+codex status github --repo MOTEB1989/Top-TieR-Global-HUB-AI
+```
+
+عندما تظهر أيقونة ✅ يكون الربط ناجحًا ويتم استيراد التعديلات تلقائيًا بعد كل commit.
+
+## 2. استعراض الـ Namespaces في قاعدة المعرفة
+
+يحتوي المشروع على سكربت `scripts/check_kb_namespaces.py` لفحص مجموعات ChromaDB.
+
+```bash
+python scripts/check_kb_namespaces.py --store-path .kb_store
+```
+
+سيعرض السكربت قائمة بالمساحات المكتشفة. مثال على المخرجات المتوقعة:
+
+```
+Detected namespaces:
+- mohsen_gj
+- saudi_banks
+- saudi_nexus
+```
+
+إذا لم تظهر أي مساحات، تأكد من أن عملية المزامنة اكتملت وأن مسار التخزين (`--store-path`) يشير إلى قاعدة المعرفة الصحيحة.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ openai==0.27.10
 # Development/testing dependencies
 pytest>=8.0.0
 pytest-asyncio>=1.0.0
+chromadb>=0.4.24

--- a/scripts/check_kb_namespaces.py
+++ b/scripts/check_kb_namespaces.py
@@ -1,0 +1,37 @@
+"""Utility script to inspect knowledge base namespaces stored in ChromaDB."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Iterable
+
+import chromadb
+
+
+def _format_namespaces(collections: Iterable[Any]) -> str:
+    names = [getattr(collection, "name", str(collection)) for collection in collections]
+    if not names:
+        return "No namespaces found in the knowledge base store."
+    lines = ["Detected namespaces:"]
+    lines.extend(f"- {name}" for name in sorted(names))
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="List namespaces that exist in the local knowledge base store.",
+    )
+    parser.add_argument(
+        "--store-path",
+        default=".kb_store",
+        help="Filesystem path where the ChromaDB persistent store is located.",
+    )
+    args = parser.parse_args()
+
+    client = chromadb.PersistentClient(path=args.store_path)
+    collections = client.list_collections()
+    print(_format_namespaces(collections))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a knowledge base guide that explains how to verify Codex linkage and per-model namespaces
- provide a helper script to list ChromaDB collections and add the chromadb dependency
- link the main README to the new troubleshooting guide

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dee925b9708320853d28a653ad0bfb