### PR TITLE
Add docker compose stack with monitoring services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,67 @@
+version: "3.9"
+
 services:
-  core:
-    build: ./core
-    ports: ["8080:8080"]
-    environment:
-      RUST_LOG: info
-  api:
+  gateway:
     build: ./services/api
-    ports: ["3000:3000"]
-    env_file: .env
-    depends_on: [core]
+    container_name: lexcode_gateway
+    ports:
+      - "3000:3000"
     environment:
-      CORE_URL: ${CORE_URL:-http://core:8080}
+      - LEXCODE_OPENAI_KEY=${LEXCODE_OPENAI_KEY}
+      - LEXCODE_HF_KEY=${LEXCODE_HF_KEY}
+      - LEXCODE_ANTHROPIC_KEY=${LEXCODE_ANTHROPIC_KEY}
+    depends_on:
+      - runner
+      - kb
+
+  runner:
+    build: ./services/runner
+    container_name: lexcode_runner
+    ports:
+      - "4000:4000"
+    environment:
+      - DB_URL=${DB_URL}
+      - OPENAI_API_KEY=${LEXCODE_OPENAI_KEY}
+
+  kb:
+    build: ./knowledge
+    container_name: lexcode_kb
+    ports:
+      - "5000:5000"
+    environment:
+      - KB_PATH=/data/kb
+    volumes:
+      - kb_data:/data
+
+  dashboard:
+    build: ./dashboard
+    container_name: lexcode_dashboard
+    ports:
+      - "8080:3000"
+    environment:
+      - NEXT_PUBLIC_API_URL=https://api.lexcode.ai
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: lexcode_prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: lexcode_grafana
+    ports:
+      - "3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+
+volumes:
+  kb_data:
+  grafana_data:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "gateway"
+    static_configs:
+      - targets: ["gateway:3000"]
+
+  - job_name: "runner"
+    static_configs:
+      - targets: ["runner:4000"]
+
+  - job_name: "kb"
+    static_configs:
+      - targets: ["kb:5000"]


### PR DESCRIPTION
## Summary
- replace the docker compose file with the full Lexcode stack including gateway, runner, kb, dashboard, Prometheus, and Grafana services
- add a Prometheus scrape configuration for the stack under monitoring/prometheus.yml

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deea376e388320bc5e7b9d5c19d020