### PR TITLE
Add Helm chart for LexCode deployment

### DIFF
--- a/lexcode-chart/Chart.yaml
+++ b/lexcode-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: lexcode
+description: Unified Helm chart for LexCode system (Gateway + Runner + KB + Dashboard + Monitoring)
+type: application
+version: 1.0.0
+appVersion: "1.0"

--- a/lexcode-chart/templates/dashboard-deploy.yaml
+++ b/lexcode-chart/templates/dashboard-deploy.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lexcode-dashboard
+spec:
+  replicas: {{ .Values.replicaCount.dashboard }}
+  selector:
+    matchLabels:
+      app: lexcode-dashboard
+  template:
+    metadata:
+      labels:
+        app: lexcode-dashboard
+    spec:
+      containers:
+        - name: dashboard
+          image: {{ .Values.image.dashboard }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.service.dashboard.port }}
+          env:
+            - name: LEXCODE_OPENAI_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lexcode-secrets
+                  key: openaiKey
+            - name: LEXCODE_HF_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lexcode-secrets
+                  key: hfKey
+            - name: LEXCODE_ANTHROPIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lexcode-secrets
+                  key: anthropicKey
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: lexcode-secrets
+                  key: dbUrl
+          {{- with .Values.resources.dashboard }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: lexcode-dashboard
+spec:
+  selector:
+    app: lexcode-dashboard
+  ports:
+    - name: http
+      port: {{ .Values.service.dashboard.port }}
+      targetPort: {{ .Values.service.dashboard.port }}
+      protocol: TCP

--- a/lexcode-chart/templates/gateway-deploy.yaml
+++ b/lexcode-chart/templates/gateway-deploy.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lexcode-gateway
+spec:
+  replicas: {{ .Values.replicaCount.gateway }}
+  selector:
+    matchLabels:
+      app: lexcode-gateway
+  template:
+    metadata:
+      labels:
+        app: lexcode-gateway
+    spec:
+      containers:
+        - name: gateway
+          image: {{ .Values.image.gateway }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.service.gateway.port }}
+          env:
+            - name: LEXCODE_OPENAI_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lexcode-secrets
+                  key: openaiKey
+            - name: LEXCODE_HF_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lexcode-secrets
+                  key: hfKey
+            - name: LEXCODE_ANTHROPIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lexcode-secrets
+                  key: anthropicKey
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: lexcode-secrets
+                  key: dbUrl
+          {{- with .Values.resources.gateway }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: lexcode-gateway
+spec:
+  selector:
+    app: lexcode-gateway
+  ports:
+    - name: http
+      port: {{ .Values.service.gateway.port }}
+      targetPort: {{ .Values.service.gateway.port }}
+      protocol: TCP

--- a/lexcode-chart/templates/grafana-deploy.yaml
+++ b/lexcode-chart/templates/grafana-deploy.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: {{ .Values.replicaCount.grafana }}
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: {{ .Values.image.grafana }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.service.grafana.port }}
+          {{- with .Values.resources.grafana }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  selector:
+    app: grafana
+  ports:
+    - name: http
+      port: {{ .Values.service.grafana.port }}
+      targetPort: {{ .Values.service.grafana.port }}
+      protocol: TCP

--- a/lexcode-chart/templates/kb-deploy.yaml
+++ b/lexcode-chart/templates/kb-deploy.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lexcode-kb
+spec:
+  replicas: {{ .Values.replicaCount.kb }}
+  selector:
+    matchLabels:
+      app: lexcode-kb
+  template:
+    metadata:
+      labels:
+        app: lexcode-kb
+    spec:
+      containers:
+        - name: kb
+          image: {{ .Values.image.kb }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.service.kb.port }}
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: lexcode-secrets
+                  key: dbUrl
+          {{- with .Values.resources.kb }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: lexcode-kb
+spec:
+  selector:
+    app: lexcode-kb
+  ports:
+    - name: http
+      port: {{ .Values.service.kb.port }}
+      targetPort: {{ .Values.service.kb.port }}
+      protocol: TCP

--- a/lexcode-chart/templates/nginx-ingress.yaml
+++ b/lexcode-chart/templates/nginx-ingress.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: lexcode-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.ingress.hosts.api }}
+        - {{ .Values.ingress.hosts.hub }}
+        - {{ .Values.ingress.hosts.grafana }}
+        - {{ .Values.ingress.hosts.kb }}
+        - {{ .Values.ingress.hosts.runner }}
+      secretName: lexcode-tls
+  rules:
+    - host: {{ .Values.ingress.hosts.api }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: lexcode-gateway
+                port:
+                  number: {{ .Values.service.gateway.port }}
+    - host: {{ .Values.ingress.hosts.hub }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: lexcode-dashboard
+                port:
+                  number: {{ .Values.service.dashboard.port }}
+    - host: {{ .Values.ingress.hosts.grafana }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: {{ .Values.service.grafana.port }}
+    - host: {{ .Values.ingress.hosts.kb }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: lexcode-kb
+                port:
+                  number: {{ .Values.service.kb.port }}
+    - host: {{ .Values.ingress.hosts.runner }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: lexcode-runner
+                port:
+                  number: {{ .Values.service.runner.port }}
+{{- end }}

--- a/lexcode-chart/templates/prometheus-deploy.yaml
+++ b/lexcode-chart/templates/prometheus-deploy.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+spec:
+  replicas: {{ .Values.replicaCount.prometheus }}
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: {{ .Values.image.prometheus }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus"
+          ports:
+            - containerPort: {{ .Values.service.prometheus.port }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus/
+              readOnly: true
+          {{- with .Values.resources.prometheus }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - name: http
+      port: {{ .Values.service.prometheus.port }}
+      targetPort: {{ .Values.service.prometheus.port }}
+      protocol: TCP
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+      - job_name: 'kubernetes-nodes'
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+      - job_name: 'kubernetes-pods'
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod

--- a/lexcode-chart/templates/runner-deploy.yaml
+++ b/lexcode-chart/templates/runner-deploy.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lexcode-runner
+spec:
+  replicas: {{ .Values.replicaCount.runner }}
+  selector:
+    matchLabels:
+      app: lexcode-runner
+  template:
+    metadata:
+      labels:
+        app: lexcode-runner
+    spec:
+      containers:
+        - name: runner
+          image: {{ .Values.image.runner }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.service.runner.port }}
+          env:
+            - name: LEXCODE_OPENAI_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lexcode-secrets
+                  key: openaiKey
+            - name: LEXCODE_HF_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lexcode-secrets
+                  key: hfKey
+            - name: LEXCODE_ANTHROPIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lexcode-secrets
+                  key: anthropicKey
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: lexcode-secrets
+                  key: dbUrl
+          {{- with .Values.resources.runner }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: lexcode-runner
+spec:
+  selector:
+    app: lexcode-runner
+  ports:
+    - name: http
+      port: {{ .Values.service.runner.port }}
+      targetPort: {{ .Values.service.runner.port }}
+      protocol: TCP

--- a/lexcode-chart/values.yaml
+++ b/lexcode-chart/values.yaml
@@ -1,0 +1,56 @@
+image:
+  gateway: myrepo/lexcode-gateway:latest
+  runner: myrepo/lexcode-runner:latest
+  kb: myrepo/lexcode-kb:latest
+  dashboard: myrepo/lexcode-dashboard:latest
+  grafana: grafana/grafana:latest
+  prometheus: prom/prometheus:latest
+
+resources:
+  gateway: {}
+  runner: {}
+  kb: {}
+  dashboard: {}
+  grafana: {}
+  prometheus: {}
+
+secrets:
+  openaiKey: "sk-xxxx"
+  hfKey: "hf_xxxx"
+  anthropicKey: "anth_xxxx"
+  dbUrl: "postgres://user:pass@db:5432/lexcode"
+
+service:
+  gateway:
+    port: 3000
+  runner:
+    port: 4000
+  kb:
+    port: 5000
+  dashboard:
+    port: 3000
+  grafana:
+    port: 3000
+  prometheus:
+    port: 9090
+
+replicaCount:
+  gateway: 2
+  runner: 1
+  kb: 1
+  dashboard: 1
+  grafana: 1
+  prometheus: 1
+
+ingress:
+  enabled: true
+  hosts:
+    api: api.lexcode.ai
+    hub: hub.lexcode.ai
+    grafana: grafana.lexcode.ai
+    kb: kb.lexcode.ai
+    runner: runner.lexcode.ai
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Summary
- add a unified Helm chart that deploys the gateway, runner, knowledge base, dashboard, Grafana, and Prometheus components
- configure shared secrets, services, and ingress routing for the LexCode endpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deeb1e40588320a0948ce9041c2d61