### PR TITLE
Add monitoring stack to LexCode Helm chart

### DIFF
--- a/helm/lexcode/Chart.yaml
+++ b/helm/lexcode/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: lexcode
+version: 0.1.0
+appVersion: "1.0.0"
+description: Helm chart for deploying LexCode services with integrated monitoring stack.
+type: application

--- a/helm/lexcode/dashboards/gateway.json
+++ b/helm/lexcode/dashboards/gateway.json
@@ -1,0 +1,89 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(gateway_http_requests_total[5m]))",
+          "legendFormat": "Gateway",
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(gateway_request_duration_seconds_bucket[5m])) by (le)) * 1000",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway Latency (p95)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "title": "Gateway Overview",
+  "uid": "gateway-overview"
+}

--- a/helm/lexcode/dashboards/runner.json
+++ b/helm/lexcode/dashboards/runner.json
@@ -1,0 +1,108 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "targets": [
+        {
+          "expr": "sum(rate(runner_tasks_total[5m]))",
+          "legendFormat": "Runner",
+          "refId": "A"
+        }
+      ],
+      "title": "Runner Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(runner_task_duration_seconds_bucket[5m])) by (le)) * 1000",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Runner Latency (p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "sum(rate(runner_task_failures_total[5m])) / sum(rate(runner_tasks_total[5m]))",
+          "legendFormat": "Failure Rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Runner Error Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "title": "Runner Metrics",
+  "uid": "runner-metrics"
+}

--- a/helm/lexcode/templates/grafana-deploy.yaml
+++ b/helm/lexcode/templates/grafana-deploy.yaml
@@ -1,0 +1,105 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.grafana }}
+{{- $dashboards := .Values.monitoring.grafana.dashboards | default (list) }}
+{{- if gt (len $dashboards) 0 }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lexcode-grafana-dashboards
+  labels:
+    grafana_dashboard: "1"
+data:
+{{- range $dashboard := $dashboards }}
+  {{ printf "%s.json" (replace (lower $dashboard.name) " " "-") }}: |
+{{ $.Files.Get $dashboard.file | indent 4 }}
+{{- end }}
+---
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lexcode-grafana-dashboard-providers
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: default
+        orgId: 1
+        folder: ""
+        type: file
+        disableDeletion: false
+        updateIntervalSeconds: 30
+        options:
+          path: /var/lib/grafana/dashboards
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lexcode-grafana-datasources
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://lexcode-prometheus:9090
+        isDefault: true
+        jsonData:
+          timeInterval: 15s
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lexcode-grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lexcode-grafana
+  template:
+    metadata:
+      labels:
+        app: lexcode-grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:latest
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              value: {{ .Values.monitoring.grafana.adminUser | quote }}
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: {{ .Values.monitoring.grafana.adminPassword | quote }}
+            - name: GF_PATHS_PROVISIONING
+              value: /etc/grafana/provisioning
+          ports:
+            - containerPort: 3000
+          volumeMounts:
+            - name: grafana-dashboards
+              mountPath: /var/lib/grafana/dashboards
+            - name: grafana-dashboard-providers
+              mountPath: /etc/grafana/provisioning/dashboards
+            - name: grafana-datasources
+              mountPath: /etc/grafana/provisioning/datasources
+      volumes:
+        - name: grafana-dashboards
+          configMap:
+            name: lexcode-grafana-dashboards
+            optional: true
+        - name: grafana-dashboard-providers
+          configMap:
+            name: lexcode-grafana-dashboard-providers
+        - name: grafana-datasources
+          configMap:
+            name: lexcode-grafana-datasources
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: lexcode-grafana
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app: lexcode-grafana
+{{- end }}

--- a/helm/lexcode/templates/prometheus-deploy.yaml
+++ b/helm/lexcode/templates/prometheus-deploy.yaml
@@ -1,0 +1,62 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.prometheus }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lexcode-prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: {{ default "30s" .Values.monitoring.prometheus.scrapeInterval }}
+    scrape_configs:
+      - job_name: "gateway"
+        static_configs:
+          - targets: ["lexcode-gateway:3000"]
+      - job_name: "runner"
+        static_configs:
+          - targets: ["lexcode-runner:4000"]
+      - job_name: "kb"
+        static_configs:
+          - targets: ["lexcode-kb:5000"]
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lexcode-prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lexcode-prometheus
+  template:
+    metadata:
+      labels:
+        app: lexcode-prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:latest
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+      volumes:
+        - name: config
+          configMap:
+            name: lexcode-prometheus-config
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: lexcode-prometheus
+spec:
+  ports:
+    - port: 9090
+      targetPort: 9090
+  selector:
+    app: lexcode-prometheus
+{{- end }}

--- a/helm/lexcode/values.yaml
+++ b/helm/lexcode/values.yaml
@@ -1,0 +1,33 @@
+image:
+  gateway: myrepo/lexcode-gateway:latest
+  runner: myrepo/lexcode-runner:latest
+  kb: myrepo/lexcode-kb:latest
+  dashboard: myrepo/lexcode-dashboard:latest
+
+secrets:
+  openaiKey: "sk-xxxx"
+  hfKey: "hf_xxxx"
+  anthropicKey: "anth_xxxx"
+  dbUrl: "postgres://user:pass@db:5432/lexcode"
+
+ingress:
+  enabled: true
+  hosts:
+    api: api.lexcode.ai
+    hub: hub.lexcode.ai
+    grafana: grafana.lexcode.ai
+    kb: kb.lexcode.ai
+    runner: runner.lexcode.ai
+
+monitoring:
+  enabled: true
+  prometheus:
+    scrapeInterval: 15s
+  grafana:
+    adminUser: admin
+    adminPassword: admin
+    dashboards:
+      - name: "Gateway Overview"
+        file: dashboards/gateway.json
+      - name: "Runner Metrics"
+        file: dashboards/runner.json


### PR DESCRIPTION
## Summary
- introduce a LexCode Helm chart with default images, secrets, ingress hosts, and monitoring configuration
- add Prometheus deployment, service, and scrape configuration for core workloads
- provision Grafana with bundled dashboards, data sources, and admin credentials for turnkey observability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deeb456ba88320b44a9b8e8f1ace7e