### PR TITLE
Add GitHub Action to run Codex compliance checks

### DIFF
--- a/.github/workflows/codex_compliance_runner.yml
+++ b/.github/workflows/codex_compliance_runner.yml
@@ -1,0 +1,31 @@
+name: Codex Compliance Runner
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  run_codex_compliance:
+    name: Run Codex API – Compliance Scenario
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Call Codex Gateway API
+        run: |
+          curl -X POST https://api.lexcode.ai/v1/lex/run \
+          -H "Content-Type: application/json" \
+          -d '{
+            "git_url": "https://github.com/MOTEB1989/Top-TieR-Global-HUB-AI.git",
+            "token": "${{ secrets.GIT_TOKEN }}",
+            "task": "finance-check",
+            "entrypoint": "ai_agents/saudi_banks/bank_compliance.py",
+            "inputs": {
+              "test_case": "aml_intl_transfer_500k_no_kyc"
+            }
+          }'
+


### PR DESCRIPTION
## Summary
- add a Codex Compliance Runner workflow to trigger the remote compliance scenario via the Codex Gateway API
- configure the workflow to run manually or on pushes to the main branch using the stored GIT_TOKEN secret

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df9562c8288320a7de401e000770ed